### PR TITLE
!breaking change/update api threshold history

### DIFF
--- a/api-backend/src/main/java/kr/cs/interdata/api_backend/controller/WebController.java
+++ b/api-backend/src/main/java/kr/cs/interdata/api_backend/controller/WebController.java
@@ -33,9 +33,14 @@ public class WebController {
         return ResponseEntity.ok(thresholdService.setThreshold(dto));
     }
 
+    // @PostMapping("/metrics/threshold-history")
+    // public ResponseEntity<?> getThresholdHistory(@RequestBody DateforHistory date) {
+    //     return ResponseEntity.ok(thresholdService.getThresholdHistory(date));
+    // }
+
     @PostMapping("/metrics/threshold-history")
-    public ResponseEntity<?> getThresholdHistory(@RequestBody DateforHistory date) {
-        return ResponseEntity.ok(thresholdService.getThresholdHistory(date));
+    public ResponseEntity<?> getThresholdHistory(@RequestBody TargetIdforHistory targetId) {
+        return ResponseEntity.ok(thresholdService.getThresholdHistoryforTargetId(targetId));
     }
 
     // SSE 방식

--- a/api-backend/src/main/java/kr/cs/interdata/api_backend/dto/TargetIdforHistory.java
+++ b/api-backend/src/main/java/kr/cs/interdata/api_backend/dto/TargetIdforHistory.java
@@ -1,0 +1,12 @@
+package kr.cs.interdata.api_backend.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TargetIdforHistory {
+
+    private String targetId;    // 임계 초과 로그를 찾을 target_ID
+}
+

--- a/api-backend/src/main/java/kr/cs/interdata/api_backend/repository/AbnormalMetricLogRepository.java
+++ b/api-backend/src/main/java/kr/cs/interdata/api_backend/repository/AbnormalMetricLogRepository.java
@@ -16,4 +16,12 @@ public interface AbnormalMetricLogRepository extends JpaRepository<AbnormalMetri
      * @return 해당 기간에 발생한 AbnormalMetricLog 리스트
      */
     List<AbnormalMetricLog> findByTimestampBetween(LocalDateTime start, LocalDateTime end);
+
+    /**
+     *  - 주어진 target ID로 필터링하여 가장 최근을 기준으로 최대 20개의 로그들을 리스트로 저장해 반환한다.
+     *
+     * @param targetId  필터링할 target ID
+     * @return  targetId = targetId인 최근 로그들 중 최대 20개를 저장한 리스트
+     */
+    List<AbnormalMetricLog> findTop20ByTargetIdOrderByTimestampDesc(String targetId);
 }

--- a/api-backend/src/main/java/kr/cs/interdata/api_backend/service/ThresholdService.java
+++ b/api-backend/src/main/java/kr/cs/interdata/api_backend/service/ThresholdService.java
@@ -98,6 +98,30 @@ public class ThresholdService {
     }
 
     /**
+     *  3. 특정 target Id의 임계값 초과 이력 조회
+     * @param targetId  조회할 target Id
+     * @return  이력 리스트
+     */
+    public List<Map<String, Object>> getThresholdHistoryforTargetId(TargetIdforHistory targetId) {
+
+        // Service를 통해 DB 조회
+        List<AbnormalMetricLog> logs = abnormalDetectionService.getLatestAbnormalMetricsByDate(targetId.getTargetId());
+
+        // 결과를 클라이언트에 맞게 매핑
+        List<Map<String, Object>> result = new ArrayList<>();
+        for (AbnormalMetricLog log : logs) {
+            Map<String, Object> record = new HashMap<>();
+            record.put("timestamp", log.getTimestamp().format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss")));
+            record.put("targetId", log.getTargetId());
+            record.put("metricName", log.getMetricName());
+            record.put("value", log.getValue().toString());
+            result.add(record);
+        }
+
+        return result;
+    }
+
+    /**
      *  4. threshold 조회
      *  -> MetricsByType 테이블의 모든 값을 조회해,
      *      모든 타입의 모든 metric의 threshold를 Map의 형태로 저장하여 return한다.

--- a/api-backend/src/main/java/kr/cs/interdata/api_backend/service/ThresholdService.java
+++ b/api-backend/src/main/java/kr/cs/interdata/api_backend/service/ThresholdService.java
@@ -105,7 +105,7 @@ public class ThresholdService {
     public List<Map<String, Object>> getThresholdHistoryforTargetId(TargetIdforHistory targetId) {
 
         // Service를 통해 DB 조회
-        List<AbnormalMetricLog> logs = abnormalDetectionService.getLatestAbnormalMetricsByDate(targetId.getTargetId());
+        List<AbnormalMetricLog> logs = abnormalDetectionService.getLatestAbnormalMetricsByTargetId(targetId.getTargetId());
 
         // 결과를 클라이언트에 맞게 매핑
         List<Map<String, Object>> result = new ArrayList<>();

--- a/api-backend/src/main/java/kr/cs/interdata/api_backend/service/repository_service/AbnormalDetectionService.java
+++ b/api-backend/src/main/java/kr/cs/interdata/api_backend/service/repository_service/AbnormalDetectionService.java
@@ -70,6 +70,21 @@ public class AbnormalDetectionService {
         return abnormalMetricLogRepository.findByTimestampBetween(startOfDay, endOfDay);
     }
 
+    /**
+     *  - 최근 이상 상태(AbnormalMetricLog)를 조회한다.
+     * <p>
+     *  - 지정한 날짜를 기준으로 임계값을 초과한 기록을 조회한다.
+     * </p>
+     *
+     * @param targetId 조회할 targetId (ex. host001, container002, ...)
+     * @return 조회된 이상 기록 리스트
+     */
+    public List<AbnormalMetricLog> getLatestAbnormalMetricsByTargetId(String targetId) {
+
+        // DB 조회 (특정 날짜의 임계치 초과 기록만 가져옴)
+        return abnormalMetricLogRepository.findTop20ByTargetIdOrderByTimestampDesc(targetId);
+    }
+
     //(선택)1달 이상 지난 로그 삭제 -> AbnrmalMetricLog
 
 }


### PR DESCRIPTION
## 주요 변경 내용

- `/api/metrics/threshold-history` API가 특정 targetId에 대한 데이터를 반환하도록 기능 업데이트

---

## 상세 설명

- 기존엔 LocalDateTime형식의 timestamp 파라미터를 기준으로 해당하는 이력 데이터를 반환했지만,
- 프론트엔드의 요청으로 API 호출 시, targetId 파라미터를 기준으로 해당하는 이력 데이터(최신 20건 등)를 반환하는 형식으로 변경했습니다.

---

## 테스트 및 검증

- targetId에 문자열 값을 전달해도 정상적으로 데이터가 조회되는지 확인
- timestamp 등 날짜 필드가 필요할 경우, 별도의 필드로 분리하여 정상 동작하는지 테스트

---

## 기타

- 해당 변경은 기존 API 사용 방식에 영향을 줄 수 있으니, 클라이언트 코드에서 targetId 전달 방식을 한 번 더 확인 부탁드립니다.
