### PR TITLE
feat: Add 'threshold' field to AnomalMetricLog entity and update rela…

### DIFF
--- a/api-backend/src/main/java/kr/cs/interdata/api_backend/dto/AlertThreshold.java
+++ b/api-backend/src/main/java/kr/cs/interdata/api_backend/dto/AlertThreshold.java
@@ -12,6 +12,7 @@ public class AlertThreshold {
 
     private String targetId;    // 메시지를 보낸 호스트/컨테이너의 고유 id
     private String metricName;  // 메트릭 이름
+    private String threshold;   // 임계값을 넘은 당시의 기준임계값
     private String value;   // 임계값을 넘은 값
 
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss", shape = JsonFormat.Shape.STRING)

--- a/api-backend/src/main/java/kr/cs/interdata/api_backend/dto/StoreViolation.java
+++ b/api-backend/src/main/java/kr/cs/interdata/api_backend/dto/StoreViolation.java
@@ -14,6 +14,7 @@ public class StoreViolation {
     private String type;    // 메세지를 보낸 머신의 타입: 호스트, 컨테이너
     private String machineId;    // 메시지를 보낸 호스트/컨테이너의 머신 id
     private String metricName;  // 메트릭 이름
+    private String threshold; // 임계값을 넘은 당시의 기준임계값
     private String value;   // 임계값을 넘은 값
 
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss", shape = JsonFormat.Shape.STRING)

--- a/api-backend/src/main/java/kr/cs/interdata/api_backend/entity/AbnormalMetricLog.java
+++ b/api-backend/src/main/java/kr/cs/interdata/api_backend/entity/AbnormalMetricLog.java
@@ -26,9 +26,10 @@ public class AbnormalMetricLog {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer number;     // 누적 값
 
-    private String targetId;   // anomaly machine's id
+    private String targetId;    // anomaly machine's id
 
-    private String metricName; // anomaly metric's name
+    private String metricName;  // anomaly metric's name
+    private Double threshold;   // anomaly가 생긴 당시의 threshold
     private Double value;       // outlier
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss", shape = JsonFormat.Shape.STRING)
     private LocalDateTime timestamp;    // anomaly가 생긴 시각

--- a/api-backend/src/main/java/kr/cs/interdata/api_backend/service/ThresholdService.java
+++ b/api-backend/src/main/java/kr/cs/interdata/api_backend/service/ThresholdService.java
@@ -90,6 +90,7 @@ public class ThresholdService {
             record.put("timestamp", log.getTimestamp().format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss")));
             record.put("targetId", log.getTargetId());
             record.put("metricName", log.getMetricName());
+            record.put("threshold", log.getThreshold());
             record.put("value", log.getValue().toString());
             result.add(record);
         }
@@ -114,6 +115,7 @@ public class ThresholdService {
             record.put("timestamp", log.getTimestamp().format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss")));
             record.put("targetId", log.getTargetId());
             record.put("metricName", log.getMetricName());
+            record.put("threshold", log.getThreshold());
             record.put("value", log.getValue().toString());
             result.add(record);
         }
@@ -150,6 +152,7 @@ public class ThresholdService {
         String type = dto.getType();
         String machineId = dto.getMachineId();
         String metricName = dto.getMetricName();
+        String threshold = dto.getThreshold();
         String value = dto.getValue();
         LocalDateTime timestamp = dto.getTimestamp();
 
@@ -159,6 +162,7 @@ public class ThresholdService {
         abnormalDetectionService.storeViolation(
                 targetId,
                 metricName,
+                threshold,
                 value,
                 timestamp
         );
@@ -168,6 +172,7 @@ public class ThresholdService {
         alert.setTargetId(targetId);
         alert.setMetricName(metricName);
         alert.setValue(value);
+        alert.setThreshold(threshold);
         alert.setTimestamp(timestamp);
 
         // 실시간 전송 (비동기 처리)

--- a/api-backend/src/main/java/kr/cs/interdata/api_backend/service/repository_service/AbnormalDetectionService.java
+++ b/api-backend/src/main/java/kr/cs/interdata/api_backend/service/repository_service/AbnormalDetectionService.java
@@ -37,12 +37,13 @@ public class AbnormalDetectionService {
      * @param value     이상값
      * @param timestamp 이상값이 발생한 시각
      */
-    public void storeViolation(String id, String metric, String value, LocalDateTime timestamp) {
+    public void storeViolation(String id, String metric, String threshold, String value, LocalDateTime timestamp) {
         // 1. AbnormalMetricLog 저장
         AbnormalMetricLog abn = new AbnormalMetricLog();
 
         abn.setTargetId(id);
         abn.setMetricName(metric);
+        abn.setThreshold(Double.valueOf(threshold));
         abn.setValue(Double.valueOf(value));
         abn.setTimestamp(timestamp);
         abnormalMetricLogRepository.save(abn);

--- a/metrics-backend/consumer/src/main/java/kr/cs/interdata/consumer/dto/ThresholdRequest.java
+++ b/metrics-backend/consumer/src/main/java/kr/cs/interdata/consumer/dto/ThresholdRequest.java
@@ -12,15 +12,17 @@ public class ThresholdRequest {
     private String type;
     private String machineId;
     private String metricName;
+    private Double threshold;
     private Double value;
 
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss", shape = JsonFormat.Shape.STRING)
     private LocalDateTime timestamp; // 임계값을 넘은 시각
 
-    public ThresholdRequest(String type, String machineId, String metricName, Double value, LocalDateTime timestamp) {
+    public ThresholdRequest(String type, String machineId, String metricName,Double threshold, Double value, LocalDateTime timestamp) {
         this.type = type;
         this.machineId = machineId;
         this.metricName = metricName;
+        this.threshold = threshold;
         this.value = value;
         this.timestamp = timestamp;
     }

--- a/metrics-backend/consumer/src/main/java/kr/cs/interdata/consumer/service/KafkaConsumerService.java
+++ b/metrics-backend/consumer/src/main/java/kr/cs/interdata/consumer/service/KafkaConsumerService.java
@@ -314,7 +314,7 @@ public class KafkaConsumerService {
 
             // 임계값 초과 데이터를 API 백엔드로 전송
             // API 호출은 대기시간이 있을 수 있으므로, sendThresholdViolation함수 내 호출에서 비동기 작업 처리한다.
-            thresholdService.sendThresholdViolation(type, machineId, metricName, value, violationTime);
+            thresholdService.sendThresholdViolation(type, machineId, metricName, threshold, value, violationTime);
 
         }
         // 임계값을 정상적으로 받아오고, 임계값이 초과되지 않음.

--- a/metrics-backend/consumer/src/main/java/kr/cs/interdata/consumer/service/ThresholdService.java
+++ b/metrics-backend/consumer/src/main/java/kr/cs/interdata/consumer/service/ThresholdService.java
@@ -32,8 +32,8 @@ public class ThresholdService {
      * @param value    : 임계값을 넘은 값
      * @param timestamp: 임계값을 넘은 시각
      */
-    public void sendThresholdViolation(String type, String machineId, String metricName, Double value, LocalDateTime timestamp) {
-        ThresholdRequest request = new ThresholdRequest(type, machineId, metricName, value, timestamp);
+    public void sendThresholdViolation(String type, String machineId, String metricName, Double threshold, Double value, LocalDateTime timestamp) {
+        ThresholdRequest request = new ThresholdRequest(type, machineId, metricName, threshold, value, timestamp);
         String url = "/api/violation-store";
 
         // API 백엔드로 POST 요청을 보내고 응답을 처리
@@ -48,8 +48,8 @@ public class ThresholdService {
                 })
                 .doOnTerminate(() -> {
                     // 성공적으로 요청을 마친 후의 처리
-                    logger.info("임계값 초과 데이터 전송 완료: type - {}, machineId - {}, metric - {}, value - {}, timestamp - {}"
-                            , type, machineId, metricName, value, timestamp);
+                    logger.info("임계값 초과 데이터 전송 완료: type - {}, machineId - {}, metric - {}, threshold - {}, value - {}, timestamp - {}"
+                            , type, machineId, metricName, threshold, value, timestamp);
                 })
                 .subscribe();  // 비동기 방식으로 호출
     }


### PR DESCRIPTION
## AnomalMetricLog 엔티티에 threshold 필드 추가 및 관련 메서드 수정

### 개요
UI 요청에 따라 `AnomalMetricLog` 엔티티에 `threshold` 필드를 추가하였으며, 이에 따라 종속된 모든 메서드들을 수정하였습니다.

### 주요 변경 사항
- `AnomalMetricLog` 엔티티에 `threshold` 필드 추가
- 관련 서비스, 리포지토리, DTO 등 모든 연관 메서드 및 클래스 수정(/metrics-backend/consumer, api-backend)

### 참고 사항
- 추가된 `threshold` 필드는 UI에서 targetId에 따른 임계값초과로그 조회를 위해 사용됩니다.

### 리뷰 요청
- 추가적으로 개선이 필요한 부분이나 누락된 사항이 있다면 코멘트 부탁드립니다.

감사합니다.
