### PR TITLE
refactor: replace System.out.println with logger

### DIFF
--- a/api-backend/src/main/java/kr/cs/interdata/api_backend/service/ThresholdService.java
+++ b/api-backend/src/main/java/kr/cs/interdata/api_backend/service/ThresholdService.java
@@ -269,8 +269,8 @@ public class ThresholdService {
 
     public List<Map<String, Object>> getThresholdHistory(HistoryFilter filter) {
         //로그 파라미터 및 filter 객체 상태 로그 출력
-        System.out.println("[LOG] getThresholdHistory 메서드 진입");
-        System.out.println("[LOG] 전달된 파라미터: " + filter);
+        logger.info("[LOG] getThresholdHistory 메서드 진입");
+        logger.info("[LOG] 전달된 파라미터: {}", filter);
 
         LocalDateTime start = null;
         LocalDateTime end = null;
@@ -282,8 +282,7 @@ public class ThresholdService {
                 start = date.atStartOfDay();// 00:00:00
                 end = date.atTime(LocalTime.MAX);// 23:59:59.999...
             } catch (Exception e) {
-                System.out.println("[ERROR] 날짜 변환 오류: " + filter.getDate());
-                e.printStackTrace();
+                logger.error("[ERROR] 날짜 변환 오류: {}", filter.getDate());
             }
         }
 
@@ -296,21 +295,19 @@ public class ThresholdService {
 
         //실제 쿼리 실행 전, 사용된 파라미터 값 로그 출력
         //잘 되는지 확인하기 위해 넣어놓음.
-        System.out.println("[LOG] findFilteredLogs 호출 파라미터:");
-        System.out.println(" start=" + start);
-        System.out.println(" end=" + end);
-        System.out.println(" machineType=" + filter.getMachineType());
-        System.out.println(" hostName=" + filter.getHostName());
-        System.out.println(" machineName=" + filter.getMachineName());
-        System.out.println(" messageType=" + filter.getMessageType());
-        System.out.println(" metricName=" + filter.getMetricName());
+        logger.info("[LOG] findFilteredLogs 호출 파라미터: " +
+                        "start={}, end={}, machineType={}, hostName={}," +
+                        " machineName={}, messageType={}, metricName={}",
+                start, end, filter.getMachineType(), filter.getHostName(),
+                filter.getMachineName(), filter.getMessageType(), filter.getMetricName());
+
 
         try {
             List<AbnormalMetricLog> logs;
 
             //날짜만 필터 시 : 해당 날짜 범위 내 이상 로그를 최신순(내림차순) 50개로 조회
             if (isOnlyDate) {
-                System.out.println("[INFO] 날짜만 들어온 요청입니다 ");
+                logger.info("[INFO] 날짜만 들어온 요청입니다 ");
                 logs=abnormalMetricLogRepository.findByTimestampBetweenOrderByTimestampDesc(start, end);
             } else {
                 //복합필터 사용 시 : 여러 조건을 조합한 쿼리로 최신순 50개 조회
@@ -325,7 +322,7 @@ public class ThresholdService {
                 );
             }
 
-            System.out.println("[LOG] 로그 쿼리 결과 개수: " + logs.size());
+            logger.info("[LOG] 로그 쿼리 결과 개수: {}", logs.size());
 
             //AdnormalMetricLog 엔티티 -> Map<String,Object> 형식으로 변환(최대 50개)
             return logs.stream()
@@ -352,8 +349,7 @@ public class ThresholdService {
                             return map;
                         } catch (Exception e) {
                             //매핑 변환 중 예외 발생 시, 로그 출력 후 무시
-                            System.out.println("[ERROR] map 변환 중 오류 발생: " + e.getMessage());
-                            e.printStackTrace();
+                            logger.error("[ERROR] map 변환 중 오류 발생: {}", e.getMessage());
                             return null;
                         }
                     })
@@ -362,8 +358,7 @@ public class ThresholdService {
 
         } catch (Exception e) {
             //전체 처리 과정에서 예외 발생 시 빈 리스트 반환
-            System.out.println("[ERROR] getThresholdHistory 전체 처리 중 오류 발생: " + e.getMessage());
-            e.printStackTrace();
+            logger.error("[ERROR] getThresholdHistory 전체 처리 중 오류 발생: {}", e.getMessage());
             return Collections.emptyList();
         }
     }

--- a/metrics-backend/consumer/src/main/java/kr/cs/interdata/consumer/config/ListenerContainerConfiguration.java
+++ b/metrics-backend/consumer/src/main/java/kr/cs/interdata/consumer/config/ListenerContainerConfiguration.java
@@ -52,13 +52,13 @@ public class ListenerContainerConfiguration {
             /* @Override
             public void onPartitionsRevokedBeforeCommit(Consumer<?, ?> consumer, Collection<TopicPartition> partitions) {
 		        // commit이 되기 전 리백런스가 발생했을 때
-                System.out.println("리밸런싱 시작 - 반납된 파티션: " + partitions);
+                logger.info("리밸런싱 시작 - 반납된 파티션: {}", partitions);
 	        }
 
             @Override
             public void onPartitionsRevokedAfterCommit(Consumer<?, ?> consumer, Collection<TopicPartition> partitions) {
                 // commit이 일어난 후에 리백런스가 발생했을 때
-                System.out.println("리밸런싱 시작 - 반납된 파티션: " + partitions);
+                logger.info("리밸런싱 시작 - 반납된 파티션: {}", partitions);
             } */
 
             @Override

--- a/metrics-backend/data-collector/src/main/java/kr/cs/interdata/datacollector/DataCollectorApplication.java
+++ b/metrics-backend/data-collector/src/main/java/kr/cs/interdata/datacollector/DataCollectorApplication.java
@@ -99,7 +99,7 @@ class KafkaProducerRunner implements CommandLineRunner {
 
                 // 4. JSON 문자열로 변환 (pretty print) 후 콘솔에 출력
                 String prettyJson = prettyMapper.writeValueAsString(hostData);
-                System.out.println(prettyJson);
+                logger.info(prettyJson);
 
                 //카프카에 메시지 전송
                 sendKafkaRecord(producer, kafkaTopic, prettyJson);
@@ -142,9 +142,9 @@ class KafkaProducerRunner implements CommandLineRunner {
         //비동기 전송 및 전송 결과 처리 콜백
         producer.send(record, (metadata, exception) -> {
             if (exception != null) {
-                System.err.println("Kafka 전송 실패: " + exception.getMessage());
+                logger.error("Kafka 전송 실패: {}", exception.getMessage());
             } else {
-                System.out.println("Kafka 전송 성공: " + metadata.topic() + " offset=" + metadata.offset());
+                logger.info("Kafka 전송 성공: {} offset= {}", metadata.topic(), metadata.offset());
             }
         });
     }


### PR DESCRIPTION
## 요약
전체 코드에서 `System.out.println`과 `e.printStackTrace()`를 적절한 logger (`logger.info`, `logger.error` 등)로 교체했습니다.

## 변경 사항
- 모든 `System.out.println` 문장을 logger로 대체
- `e.printStackTrace()` 호출을 `logger.error("예외 발생", e)` 형식으로 변경
- `System.out.println`과 `e.printStackTrace()`를 동시에 사용하는 중복 로그 출력 방식 제거
- 로그 메시지 형식을 통일하여 가독성과 유지보수성 향상

## 작업 배경
- 로그 레벨에 따른 구분이 가능한 로깅 시스템 도입
- 운영 환경에서도 활용 가능한 일관된 로깅 방식 적용
